### PR TITLE
This fixes handling of *js.Object arguments for replications

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -114,8 +114,9 @@ func replicationEndpoint(dsn string, object interface{}) (name string, obj inter
 	}
 	switch t := object.(type) {
 	case *js.Object:
+		tx := object.(*js.Object) // https://github.com/gopherjs/gopherjs/issues/682
 		// Assume it's a raw PouchDB object
-		return t.Get("name").String(), t, nil
+		return tx.Get("name").String(), tx, nil
 	case *bindings.DB:
 		// Unwrap the bare object
 		return t.Object.Get("name").String(), t.Object, nil

--- a/test/test.go
+++ b/test/test.go
@@ -23,8 +23,6 @@ func init() {
 // RegisterPouchDBSuites registers the PouchDB test suites.
 func RegisterPouchDBSuites() {
 	kiviktest.RegisterSuite(kiviktest.SuitePouchLocal, kt.SuiteConfig{
-		"db": map[string]interface{}{"db": js.Global.Call("require", "memdown")},
-
 		"PreCleanup.skip": true,
 
 		// Features which are not supported by PouchDB


### PR DESCRIPTION
The previous logic failed to work due to an apparent bug in GopherJS (https://github.com/gopherjs/gopherjs/issues/682).  This works around that behavior.

Also, remove the now obsolete `db` options in the test definitions.