### PR TITLE
Replace Buffer constructor with Buffer.from, where supported

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,14 +50,9 @@ pouchdb7:
         NODE_VER: 12
         NPM_PROFILE: pouchdb7-package.json
 
-lint:
+linter:
     stage: test
-    image: golang:1.13
-    services: []
-    before_script:
-        - ''
+    image: golangci/golangci-lint:v1.26
     script:
         - go mod download
-        - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
-        - ./script/test_version.sh
         - golangci-lint run ./...

--- a/attachments.go
+++ b/attachments.go
@@ -32,7 +32,7 @@ func (d *db) GetAttachment(ctx context.Context, docID, filename string, opts map
 
 func parseAttachment(obj *js.Object) (att *driver.Attachment, err error) {
 	defer bindings.RecoverError(&err)
-	if jsbuiltin.TypeOf(obj.Get("write")) == "function" {
+	if jsbuiltin.TypeOf(obj.Get("write")) == jsbuiltin.TypeFunction {
 		// This looks like a Buffer object; we're in Node.js
 		body := obj.Call("toString", "binary").String()
 		// It might make sense to wrap the Buffer itself in an io.Reader interface,

--- a/bindings/pouchdb.go
+++ b/bindings/pouchdb.go
@@ -292,6 +292,11 @@ func attachmentObject(contentType string, content io.Reader) (att *js.Object, er
 	}
 	if buffer := js.Global.Get("Buffer"); jsbuiltin.TypeOf(buffer) == "function" {
 		// The Buffer type is supported, so we'll use that
+		if jsbuiltin.TypeOf(buffer.Get("from")) == "function" {
+			// For newer versions of Node.js. See https://nodejs.org/fa/docs/guides/buffer-constructor-deprecation/
+			return buffer.Call("from", buf.String()), nil
+		}
+		// Fall back to legacy Buffer constructor.
 		return buffer.New(buf.String()), nil
 	}
 	if js.Global.Get("Blob") != js.Undefined {

--- a/bindings/pouchdb.go
+++ b/bindings/pouchdb.go
@@ -100,7 +100,7 @@ func callBack(ctx context.Context, o caller, method string, args ...interface{})
 
 // AllDBs returns the list of all existing (undeleted) databases.
 func (p *PouchDB) AllDBs(ctx context.Context) ([]string, error) {
-	if jsbuiltin.TypeOf(p.Get("allDbs")) != "function" {
+	if jsbuiltin.TypeOf(p.Get("allDbs")) != jsbuiltin.TypeFunction {
 		return nil, errors.New("pouchdb-all-dbs plugin not loaded")
 	}
 	result, err := callBack(ctx, p, "allDbs")
@@ -290,9 +290,9 @@ func attachmentObject(contentType string, content io.Reader) (att *js.Object, er
 	if _, err := buf.ReadFrom(content); err != nil {
 		return nil, err
 	}
-	if buffer := js.Global.Get("Buffer"); jsbuiltin.TypeOf(buffer) == "function" {
+	if buffer := js.Global.Get("Buffer"); jsbuiltin.TypeOf(buffer) == jsbuiltin.TypeFunction {
 		// The Buffer type is supported, so we'll use that
-		if jsbuiltin.TypeOf(buffer.Get("from")) == "function" {
+		if jsbuiltin.TypeOf(buffer.Get("from")) == jsbuiltin.TypeFunction {
 			// For newer versions of Node.js. See https://nodejs.org/fa/docs/guides/buffer-constructor-deprecation/
 			return buffer.Call("from", buf.String()), nil
 		}


### PR DESCRIPTION
Fix for deprecated `Buffer`

> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.